### PR TITLE
Change Multiple Gender-Biased Terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Guidelines
 1) Prevent overblocking by utilizing the [law of diminishing returns](https://pmctraining.com/site/wp-content/uploads/2018/04/Law-of-Diminishing-Returns-CHART.png) (e.g., using [sane](https://privacyguides.org/basics/threat-modeling), quality blocklists).
-2) Pass the [girlfriend test](https://urbandictionary.com/define.php?term=Grandma%20Test) with few exceptions. These deviations are documented throughout the guide.
+2) Pass the user-friendliness tests with few exceptions. These deviations are documented throughout the guide.
 
 ***
 
@@ -313,8 +313,8 @@ Let's use the profile names from earlier. You might have:
 | Firefox         | Hardened             |
 | Chrome          | Hardened             |
 | iPhone          | Hardened             |
-| Wife's iPhone   | Relaxed              |
-| Wife's Mac      | Relaxed              |
+| Spouse's iPhone | Relaxed              |
+| Spouse's Mac    | Relaxed              |
 | Susie's iPad    | Kids                 |
 | Living Room TV  | Basic                |
 | Router          | Basic                |


### PR DESCRIPTION
First off, I want to say your config guidelines are very useful. Thanks for putting in all that effort. I've got a couple of suggestions:

#### Proposed Changes

1. **"Girlfriend Test"**, **"Grandma Test"**
   - The term "girlfriend test" and the link to the Urban Dictionary page for "Grandma Test" are biased and offensive.
   - **How About**: Replace "girlfriend test" with "user-friendliness test" or "accessibility test" to maintain neutrality.

2. Device Names such as **Wife's iPhone**
   - Referring to "wife's iPhone" assumes a lot about who uses what.
   - **How About**: Using "partner" or "spouse" makes it clear we’re simply talking about anyone’s device.

Fun fact, a "grandma" I know actually holds a degree in Electrical Engineering and has a deep understanding of DNS, having implemented infras on a national level in the 80s, some of which is still in use today.

Thanks for considering these changes